### PR TITLE
Fixed the hover-effect bug in dark-mode under navbar section

### DIFF
--- a/style.css
+++ b/style.css
@@ -370,6 +370,9 @@ footer {
 .dark-anchor-tag{
   color: white;
 }
+.dark-anchor-tag:hover{
+  color: white;
+}
 .dark-card{
   background-color: #121212;
 }


### PR DESCRIPTION
I encountered a bug that whenever we toggle dark mode and then hover our mouse on navbar then its list items get disappear. This happened because earlier I didn't updated the hover effect css  for the same in dark mode.

Now I have updated it and now it's working fine.

# Here is a screenshot of the bug which is now resolved : 
You can see how `opportunities` section got disappear when we hover on it, this was due to its color was set to black when we hover on it, now I have changed it to white whenever we hover on it.
<img width="1437" alt="Screenshot 2022-10-02 at 2 54 01 PM" src="https://user-images.githubusercontent.com/96296951/193447316-95c887ab-0dfc-4baa-84fa-93af526f819d.png">

