### PR TITLE
Center join-us icons

### DIFF
--- a/style.css
+++ b/style.css
@@ -211,7 +211,8 @@ hr {
 /**Joinus container styling starts**/
 
 .joinus-anchor {
-  margin-left: 5%;
+  margin-left: 2.5%;
+  margin-right: 2.5%;
   margin-top: 5vh;
 }
 


### PR DESCRIPTION
Join us icons were left-aligned and not centered, fixed by changing the margin to be equal on either side